### PR TITLE
fix: prevent _Process / greenlet leak on termination and external kill

### DIFF
--- a/simulus/process.py
+++ b/simulus/process.py
@@ -177,8 +177,22 @@ class _Process(Trappable):
         #log.debug('process terminated at time=%g' % self._sim.now)
         self._sim._runtime["terminated_processes"] += 1
 
-        #raise greenlet.GreenletExit
-        self.main.switch()
+        # let invoke() return so the greenlet dies on its own; greenlet
+        # jumps to vert.parent automatically when the start function
+        # returns. without this the greenlet would stay suspended,
+        # pinning self via the bound _Process.invoke method (issue #22).
+        self.vert.parent = self.main
+
+    def _kill_greenlet(self):
+        """Force a suspended greenlet to die after external kill.
+
+        Called by simulator.kill() when terminating another process.
+        Without this the greenlet stays suspended holding a reference
+        to self via _Process.invoke (issue #22).
+        """
+        if self.vert is not None and not self.vert.dead:
+            self.vert.parent = greenlet.getcurrent()
+            self.vert.throw()  # raises GreenletExit at suspension point
 
     def set_priority(self, prio, prio_args):
         """Set the priority of this process (either a value or a function that

--- a/simulus/simulator.py
+++ b/simulus/simulator.py
@@ -410,6 +410,7 @@ class simulator:
                 self._runtime["cancelled_processes"] += 1
                 p.deactivate(_Process.STATE_TERMINATED)
                 p.trap.trigger()
+                p._kill_greenlet()
             else:
                 # otherwise, it's already killed; we do nothing
                 #log.debug("[r%d] simulator '%s' kill non-active process at time=%g" %

--- a/tests/test_process_leak.py
+++ b/tests/test_process_leak.py
@@ -1,0 +1,53 @@
+"""Regression test for issue #22: _Process / greenlet leak."""
+
+import gc
+
+import simulus
+from simulus.process import _Process
+
+
+def _live_processes_for(sim):
+    return [o for o in gc.get_objects()
+            if isinstance(o, _Process) and o._sim is sim]
+
+
+def test_process_releases_after_natural_exit():
+    sim = simulus.simulator()
+
+    def f():
+        sim.sleep(1)
+
+    procs = [sim.process(f) for _ in range(10)]
+    sim.run()
+    assert sim.now == 1
+
+    for p in procs:
+        assert p.vert.dead, "greenlet not dead after natural exit"
+
+    del procs, p
+    gc.collect()
+    assert _live_processes_for(sim) == [], \
+        "leaked _Process bound to this simulator after natural exit"
+
+
+def test_process_releases_after_external_kill():
+    sim = simulus.simulator()
+
+    def f():
+        sim.sleep(1000)  # long sleep — kill before it wakes
+
+    procs = [sim.process(f) for _ in range(10)]
+    # advance into the processes so each greenlet is started and
+    # suspended, not still in STATE_STARTED
+    sim.run(until=0.5)
+    for p in procs:
+        sim.kill(p)
+    sim.run(until=2000)  # drain anything else
+
+    for p in procs:
+        assert p.vert.dead, "greenlet not dead after external kill"
+
+    del procs, p
+    gc.collect()
+    assert _live_processes_for(sim) == [], \
+        "leaked _Process bound to this simulator after external kill"


### PR DESCRIPTION
## Summary

- `_Process.terminate()` ended with `self.main.switch()`, keeping the greenlet alive (suspended) and pinning the `_Process` via `_Process.invoke`. Same leak occurred when `simulator.kill()` terminated another process — the greenlet was never killed.
- Now `terminate()` lets `invoke()` return naturally (sets `vert.parent` so the greenlet auto-switches to the simulator main on death), and `simulator.kill()` throws `GreenletExit` into the suspended greenlet via a new `_Process._kill_greenlet()` helper.
- Adds `tests/test_process_leak.py` covering both natural-exit and external-kill paths.

Fixes #22

## Test plan

- [x] `pytest tests/regress.py` — all 26 example scripts pass, no regressions
- [x] `pytest tests/test_process_leak.py` — both new tests pass (greenlets dead, no leaked `_Process` objects after GC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)